### PR TITLE
Set fastcgi_buffer_size in nginx.template.conf to account for large Inertia responses

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -163,6 +163,7 @@ http {
         ) else ()
      
         location ~ \.php$ {
+            fastcgi_buffer_size 8k;
             fastcgi_pass 127.0.0.1:9000;
             fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
             include $!{nginx}/conf/fastcgi_params;


### PR DESCRIPTION
This PR sets nginx's `fastcgi_buffer_size` to 8k like proposed in this [issue comment](https://github.com/inertiajs/inertia-laravel/issues/529#issuecomment-2229635151). This fixes the [issue](https://github.com/inertiajs/inertia-laravel/issues/529) with large Inertia responses being limited by the default `fastcgi_buffer_size`.

Could be helpful for other Coolify + Laravel + Inertia.js users.

P.S.: Thanks a lot for your work on this, I don't think I would have been able to set up my Laravel app in Coolify properly without your blog posts and this repo 🙏🏻